### PR TITLE
fix: firefox footer not hidden

### DIFF
--- a/style.css
+++ b/style.css
@@ -15,7 +15,6 @@ object#comfyui_webui_root {
     height: 100%;
 }
 
-#tabs:has( > div#tab_comfyui_webui_root[style*="display: block;"]) ~ #footer,
 .comfyui-remove-display {
     display: none;
 }


### PR DESCRIPTION
This line prevents firefox from hiding the footer and is no more necessary for other browsers to work.