### PR TITLE
lazy load webui checkpoint

### DIFF
--- a/comfyui_custom_nodes/webui_checkpoint_loader.py
+++ b/comfyui_custom_nodes/webui_checkpoint_loader.py
@@ -37,7 +37,9 @@ class WebuiCheckpointLoader:
     CATEGORY = "loaders"
 
     def load_checkpoint(self, void):
-        with CheckpointLoaderPatched(shared.sd_model_state_dict) as patched_loader:
+        shared.send_state_dict_event.set()
+        state_dict = shared.state_dict_queue.get()
+        with CheckpointLoaderPatched(state_dict) as patched_loader:
             return patched_loader.load()
 
 

--- a/comfyui_custom_nodes/webui_checkpoint_loader.py
+++ b/comfyui_custom_nodes/webui_checkpoint_loader.py
@@ -37,7 +37,6 @@ class WebuiCheckpointLoader:
     CATEGORY = "loaders"
 
     def load_checkpoint(self, void):
-        webui_process.send_state_dict_event.set()
         state_dict = webui_process.state_dict_queue.get()
         with CheckpointLoaderPatched(state_dict) as patched_loader:
             return patched_loader.load()

--- a/comfyui_custom_nodes/webui_checkpoint_loader.py
+++ b/comfyui_custom_nodes/webui_checkpoint_loader.py
@@ -1,4 +1,4 @@
-from modules import shared
+import webui_process
 from comfy.sd import load_checkpoint_guess_config
 from comfy import utils
 
@@ -37,8 +37,8 @@ class WebuiCheckpointLoader:
     CATEGORY = "loaders"
 
     def load_checkpoint(self, void):
-        shared.send_state_dict_event.set()
-        state_dict = shared.state_dict_queue.get()
+        webui_process.send_state_dict_event.set()
+        state_dict = webui_process.state_dict_queue.get()
         with CheckpointLoaderPatched(state_dict) as patched_loader:
             return patched_loader.load()
 

--- a/lib_comfyui/async_comfyui_loader.py
+++ b/lib_comfyui/async_comfyui_loader.py
@@ -7,10 +7,9 @@ from torch import multiprocessing
 from lib_comfyui import argv_conversion, custom_extension_injector, webui_resources_sharing
 
 
-def main(state_dict_queue, send_state_dict_event, comfyui_path):
+def main(state_dict_queue, comfyui_path):
     sys.modules["webui_process"] = WebuiProcessData(
-        state_dict_queue,
-        send_state_dict_event,
+        state_dict_queue=state_dict_queue,
     )
     start_comfyui(comfyui_path)
 
@@ -30,4 +29,3 @@ def start_comfyui(comfyui_path):
 @dataclasses.dataclass
 class WebuiProcessData(types.ModuleType):
     state_dict_queue: multiprocessing.Queue
-    send_state_dict_event: multiprocessing.Event

--- a/lib_comfyui/async_comfyui_loader.py
+++ b/lib_comfyui/async_comfyui_loader.py
@@ -1,13 +1,17 @@
+import dataclasses
+import types
 import sys
 import os
 import runpy
-from modules import shared
+from torch import multiprocessing
 from lib_comfyui import argv_conversion, custom_extension_injector, webui_resources_sharing
 
 
 def main(state_dict_queue, send_state_dict_event, comfyui_path):
-    shared.state_dict_queue = state_dict_queue
-    shared.send_state_dict_event = send_state_dict_event
+    sys.modules["webui_process"] = WebuiProcessData(
+        state_dict_queue,
+        send_state_dict_event,
+    )
     start_comfyui(comfyui_path)
 
 
@@ -21,3 +25,9 @@ def start_comfyui(comfyui_path):
     custom_extension_injector.register_webui_extensions()
     print('[sd-webui-comfyui]', f'Launching ComfyUI with arguments: {" ".join(sys.argv[1:])}')
     runpy.run_path(os.path.join(comfyui_path, "main.py"), {}, '__main__')
+
+
+@dataclasses.dataclass
+class WebuiProcessData(types.ModuleType):
+    state_dict_queue: multiprocessing.Queue
+    send_state_dict_event: multiprocessing.Event

--- a/lib_comfyui/async_comfyui_loader.py
+++ b/lib_comfyui/async_comfyui_loader.py
@@ -2,12 +2,12 @@ import sys
 import os
 import runpy
 from modules import shared
-import threading
 from lib_comfyui import argv_conversion, custom_extension_injector, webui_resources_sharing
 
 
-def main(model_name_queue, comfyui_path):
-    start_update_loop(model_name_queue)
+def main(state_dict_queue, send_state_dict_event, comfyui_path):
+    shared.state_dict_queue = state_dict_queue
+    shared.send_state_dict_event = send_state_dict_event
     start_comfyui(comfyui_path)
 
 
@@ -21,11 +21,3 @@ def start_comfyui(comfyui_path):
     custom_extension_injector.register_webui_extensions()
     print('[sd-webui-comfyui]', f'Launching ComfyUI with arguments: {" ".join(sys.argv[1:])}')
     runpy.run_path(os.path.join(comfyui_path, "main.py"), {}, '__main__')
-
-
-def start_update_loop(model_state_dict_queue):
-    def update_queue():
-        while True:
-            shared.sd_model_state_dict = model_state_dict_queue.get()
-
-    threading.Thread(target=update_queue, daemon=True).start()

--- a/lib_comfyui/async_comfyui_loader.py
+++ b/lib_comfyui/async_comfyui_loader.py
@@ -8,7 +8,7 @@ from lib_comfyui import argv_conversion, custom_extension_injector, webui_resour
 
 
 def main(state_dict_queue, comfyui_path):
-    sys.modules["webui_process"] = WebuiProcessData(
+    sys.modules["webui_process"] = WebuiProcessModule(
         state_dict_queue=state_dict_queue,
     )
     start_comfyui(comfyui_path)
@@ -27,5 +27,5 @@ def start_comfyui(comfyui_path):
 
 
 @dataclasses.dataclass
-class WebuiProcessData(types.ModuleType):
+class WebuiProcessModule(types.ModuleType):
     state_dict_queue: multiprocessing.Queue

--- a/lib_comfyui/comfyui_adapter.py
+++ b/lib_comfyui/comfyui_adapter.py
@@ -1,16 +1,28 @@
 import sys
 import os
 from torch import multiprocessing
-import threading
 from lib_comfyui import async_comfyui_loader, webui_settings
+from lib_comfyui.parallel_utils import StoppableThread, SynchronizingQueue
 from modules import shared
+
+
+def get_cpu_state_dict():
+    return unwrap_cpu_state_dict(shared.sd_model.state_dict())
+
+
+def unwrap_cpu_state_dict(state_dict: dict) -> dict:
+    model_key_prefixes = ('cond_stage_model', 'first_stage_model', 'model.diffusion_model')
+    return {
+        k.replace('.wrapped.', '.'): v.cpu().share_memory_()
+        for k, v in state_dict.items()
+        if k.startswith(model_key_prefixes)
+    }
 
 
 comfyui_process = None
 state_dict_thread = None
-send_state_dict_event = multiprocessing.Event()
 multiprocessing_spawn = multiprocessing.get_context('spawn')
-state_dict_queue = multiprocessing_spawn.Queue()
+state_dict_queue = SynchronizingQueue(get_cpu_state_dict, ctx=multiprocessing_spawn)
 
 
 def start():
@@ -28,7 +40,11 @@ def start_comfyui_process(install_location):
     sys_path_to_add = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
     try:
         sys.path.insert(0, sys_path_to_add)
-        comfyui_process = multiprocessing_spawn.Process(target=async_comfyui_loader.main, args=(state_dict_queue, send_state_dict_event, install_location), daemon=True)
+        comfyui_process = multiprocessing_spawn.Process(
+            target=async_comfyui_loader.main,
+            args=(state_dict_queue, install_location),
+            daemon=True,
+        )
         comfyui_process.start()
     finally:
         sys.path.clear()
@@ -41,26 +57,10 @@ def start_state_dict_thread():
     def thread_loop():
         global state_dict_thread, state_dict_queue
         while state_dict_thread.is_running():
-            send_state_dict = send_state_dict_event.wait(1)
-            if not send_state_dict: continue
-            send_state_dict_event.clear()
-
-            state_dict = unwrap_cpu_state_dict(shared.sd_model.state_dict())
-            if not state_dict_thread.is_running(): return
-
-            state_dict_queue.put(state_dict)
+            state_dict_queue.attend_consumer(timeout=1)
 
     state_dict_thread = StoppableThread(target=thread_loop, daemon=True)
     state_dict_thread.start()
-
-
-def unwrap_cpu_state_dict(state_dict: dict) -> dict:
-    model_key_prefixes = ('cond_stage_model', 'first_stage_model', 'model.diffusion_model')
-    return {
-        k.replace('.wrapped.', '.'): v.cpu().share_memory_()
-        for k, v in state_dict.items()
-        if k.startswith(model_key_prefixes)
-    }
 
 
 def stop():
@@ -82,21 +82,5 @@ def stop_state_dict_thread():
     if state_dict_thread is None:
         return
 
-    state_dict_thread.stop()
-    send_state_dict_event.set()
-
     state_dict_thread.join()
     state_dict_thread = None
-    send_state_dict_event.clear()
-
-
-class StoppableThread(threading.Thread):
-    def __init__(self, *args, **kwargs):
-        super(StoppableThread, self).__init__(*args, **kwargs)
-        self._stop_event = threading.Event()
-
-    def stop(self):
-        self._stop_event.set()
-
-    def is_running(self):
-        return not self._stop_event.is_set()

--- a/lib_comfyui/comfyui_adapter.py
+++ b/lib_comfyui/comfyui_adapter.py
@@ -1,17 +1,57 @@
 import sys
 import os
 from torch import multiprocessing
+import threading
 from lib_comfyui import async_comfyui_loader, webui_settings
+from modules import shared
 
 
-thread = None
+comfyui_process = None
+state_dict_thread = None
+send_state_dict_event = multiprocessing.Event()
 multiprocessing_spawn = multiprocessing.get_context('spawn')
-model_queue = multiprocessing_spawn.Queue()
+state_dict_queue = multiprocessing_spawn.Queue()
 
 
-def on_model_loaded(sd_model):
-    state_dict = unwrap_cpu_state_dict(sd_model.state_dict())
-    model_queue.put(state_dict)
+def start():
+    install_location = webui_settings.get_install_location()
+    if not os.path.exists(install_location):
+        return
+
+    start_state_dict_thread()
+    start_comfyui_process(install_location)
+
+
+def start_comfyui_process(install_location):
+    global comfyui_process
+    original_sys_path = list(sys.path)
+    sys_path_to_add = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+    try:
+        sys.path.insert(0, sys_path_to_add)
+        comfyui_process = multiprocessing_spawn.Process(target=async_comfyui_loader.main, args=(state_dict_queue, send_state_dict_event, install_location), daemon=True)
+        comfyui_process.start()
+    finally:
+        sys.path.clear()
+        sys.path.extend(original_sys_path)
+
+
+def start_state_dict_thread():
+    global state_dict_thread
+
+    def thread_loop():
+        global state_dict_thread, state_dict_queue
+        while state_dict_thread.is_running():
+            send_state_dict = send_state_dict_event.wait(1)
+            if not send_state_dict: continue
+            send_state_dict_event.clear()
+
+            state_dict = unwrap_cpu_state_dict(shared.sd_model.state_dict())
+            if not state_dict_thread.is_running(): return
+
+            state_dict_queue.put(state_dict)
+
+    state_dict_thread = StoppableThread(target=thread_loop, daemon=True)
+    state_dict_thread.start()
 
 
 def unwrap_cpu_state_dict(state_dict: dict) -> dict:
@@ -23,31 +63,40 @@ def unwrap_cpu_state_dict(state_dict: dict) -> dict:
     }
 
 
-def start():
-    install_location = webui_settings.get_install_location()
-    if not os.path.exists(install_location):
-        return
-
-    start_comfyui_process(install_location)
-
-
-def start_comfyui_process(install_location):
-    global thread
-    original_sys_path = list(sys.path)
-    sys_path_to_add = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-    try:
-        sys.path.insert(0, sys_path_to_add)
-        thread = multiprocessing_spawn.Process(target=async_comfyui_loader.main, args=(model_queue, install_location), daemon=True)
-        thread.start()
-    finally:
-        sys.path.clear()
-        sys.path.extend(original_sys_path)
-
-
 def stop():
-    global thread
-    if thread is None:
+    stop_comfyui_process()
+    stop_state_dict_thread()
+
+
+def stop_comfyui_process():
+    global comfyui_process
+    if comfyui_process is None:
         return
 
-    thread.terminate()
-    thread = None
+    comfyui_process.terminate()
+    comfyui_process = None
+
+
+def stop_state_dict_thread():
+    global state_dict_thread, state_dict_queue
+    if state_dict_thread is None:
+        return
+
+    state_dict_thread.stop()
+    send_state_dict_event.set()
+
+    state_dict_thread.join()
+    state_dict_thread = None
+    send_state_dict_event.clear()
+
+
+class StoppableThread(threading.Thread):
+    def __init__(self, *args, **kwargs):
+        super(StoppableThread, self).__init__(*args, **kwargs)
+        self._stop_event = threading.Event()
+
+    def stop(self):
+        self._stop_event.set()
+
+    def is_running(self):
+        return not self._stop_event.is_set()

--- a/lib_comfyui/comfyui_adapter.py
+++ b/lib_comfyui/comfyui_adapter.py
@@ -78,7 +78,7 @@ def stop_comfyui_process():
 
 
 def stop_state_dict_thread():
-    global state_dict_thread, state_dict_queue
+    global state_dict_thread
     if state_dict_thread is None:
         return
 

--- a/lib_comfyui/parallel_utils.py
+++ b/lib_comfyui/parallel_utils.py
@@ -1,0 +1,50 @@
+import threading
+from torch import multiprocessing
+import multiprocessing.queues
+
+
+class StoppableThread(threading.Thread):
+    def __init__(self, *args, **kwargs):
+        super(StoppableThread, self).__init__(*args, **kwargs)
+        self._stop_event = threading.Event()
+
+    def stop(self):
+        self._stop_event.set()
+
+    def join(self, *args, **kwargs) -> None:
+        self.stop()
+        super(StoppableThread, self).join(*args, **kwargs)
+
+    def is_running(self):
+        return not self._stop_event.is_set()
+
+
+class SynchronizingQueue(multiprocessing.queues.Queue):
+    def __init__(self, producer, *args, ctx=None, **kwargs):
+        if ctx is None:
+            ctx = multiprocessing.get_context()
+
+        super(SynchronizingQueue, self).__init__(*args, ctx=ctx, **kwargs)
+        self._consumer_ready_event = multiprocessing.Event()
+        self._producer = producer
+
+    def attend_consumer(self, timeout: float = None):
+        consumer_ready = self._wait_for_consumer(timeout)
+        if not consumer_ready: return
+        self.put(self._producer())
+
+    def _wait_for_consumer(self, timeout: float = None):
+        consumer_ready = self._consumer_ready_event.wait(timeout)
+        self._consumer_ready_event.clear()
+        return consumer_ready
+
+    def get(self, *args, **kwargs):
+        self._consumer_ready_event.set()
+        return super(SynchronizingQueue, self).get(*args, **kwargs)
+
+    def __getstate__(self):
+        return super(SynchronizingQueue, self).__getstate__() + (self._consumer_ready_event, self._producer)
+
+    def __setstate__(self, state):
+        *state, self._consumer_ready_event, self._producer = state
+        return super(SynchronizingQueue, self).__setstate__(state)

--- a/lib_comfyui/webui_callbacks.py
+++ b/lib_comfyui/webui_callbacks.py
@@ -18,13 +18,8 @@ def on_script_unloaded():
     comfyui_adapter.stop()
 
 
-def on_model_loaded(sd_model):
-    comfyui_adapter.on_model_loaded(sd_model)
-
-
 def register_callbacks():
     script_callbacks.on_ui_tabs(on_ui_tabs)
     script_callbacks.on_ui_settings(on_ui_settings)
     script_callbacks.on_app_started(on_app_started)
     script_callbacks.on_script_unloaded(on_script_unloaded)
-    script_callbacks.on_model_loaded(on_model_loaded)


### PR DESCRIPTION
Lazy load the webui checkpoint in comfyui. Although it isn't the best workaround, reloading the gradio UI clears the cpu copy from memory.