### PR TITLE
fix png info for missing workflow type keys

### DIFF
--- a/scripts/comfyui.py
+++ b/scripts/comfyui.py
@@ -85,8 +85,9 @@ class ComfyUIScript(scripts.Script):
             if not serialized_graphs:
                 return gr.Textbox.update(value='')
 
+            serialized_graphs = json.loads(serialized_graphs)
             workflow_graphs = {
-                workflow_type.get_ids(xxx2img)[0]: json.loads(serialized_graphs).get(workflow_type.base_id, workflow_type.default_workflow)
+                workflow_type.get_ids(xxx2img)[0]: serialized_graphs.get(workflow_type.base_id, json.loads(workflow_type.default_workflow))
                 for workflow_type in workflow_types
             }
 


### PR DESCRIPTION
loading missing keys does not work, we need to json.loads the default workflow before sending it over to comfy clients.