### PR TITLE
fix return type of the `FromWebui` node

### DIFF
--- a/comfyui_custom_nodes/webui_io.py
+++ b/comfyui_custom_nodes/webui_io.py
@@ -1,6 +1,19 @@
 from lib_comfyui import global_state
 
 
+class AnyType(str):
+    def __ne__(self, _) -> bool:
+        return False
+
+
+class AnyReturnTypes(tuple):
+    def __init__(self):
+        super().__init__()
+
+    def __getitem__(self, _):
+        return AnyType()
+
+
 class FromWebui:
     @classmethod
     def INPUT_TYPES(cls):
@@ -9,7 +22,7 @@ class FromWebui:
                 "void": ("VOID", ),
             },
         }
-    RETURN_TYPES = ()
+    RETURN_TYPES = AnyReturnTypes()
     RETURN_NAMES = ()
     FUNCTION = "get_node_inputs"
 


### PR DESCRIPTION
Subclass tuple and patch the `__getitem__` method to return an any string so that type checking always works. A safer fix would be to update RETURN_TYPES each time a workflow is ran.

close #145 