### PR TITLE
fix for latest comfyui update

### DIFF
--- a/install_comfyui.py
+++ b/install_comfyui.py
@@ -14,6 +14,10 @@ def main(install_location):
 
 def update(install_location):
     print("[sd-webui-comfyui]", f"Updating comfyui at {install_location}...")
+    if not install_location.is_dir() or not any(install_location.iterdir()):
+        print("[sd-webui-comfyui]", f"Cannot update comfyui since it is not installed.", file=sys.stderr)
+        return
+
     import git
     repo = git.Repo(install_location)
     current = repo.head.commit

--- a/install_comfyui.py
+++ b/install_comfyui.py
@@ -12,6 +12,18 @@ def main(install_location):
     git.Repo.clone_from(git_repo_url, install_location)
 
 
+def update(install_location):
+    print("[sd-webui-comfyui]", f"Updating comfyui at {install_location}...")
+    import git
+    repo = git.Repo(install_location)
+    current = repo.head.commit
+    repo.remotes.origin.pull()
+    if current == repo.head.commit:
+        print("[sd-webui-comfyui", "Already up to date.")
+    else:
+        print("[sd-webui-comfyui]", "Done updating comfyui.")
+
+
 if __name__ == '__main__':
     install_location = default_install_location
     if len(sys.argv) > 1:

--- a/install_comfyui.py
+++ b/install_comfyui.py
@@ -23,7 +23,7 @@ def update(install_location):
     current = repo.head.commit
     repo.remotes.origin.pull()
     if current == repo.head.commit:
-        print("[sd-webui-comfyui", "Already up to date.")
+        print("[sd-webui-comfyui]", "Already up to date.")
     else:
         print("[sd-webui-comfyui]", "Done updating comfyui.")
 

--- a/lib_comfyui/webui/callbacks.py
+++ b/lib_comfyui/webui/callbacks.py
@@ -24,7 +24,8 @@ def on_ui_settings():
 
 @ipc.restrict_to_process('webui')
 def on_after_component(*args, **kwargs):
-    return patches.watch_prompts(*args, **kwargs)
+    patches.watch_prompts(*args, **kwargs)
+    settings.subscribe_update_button(*args, **kwargs)
 
 
 @ipc.restrict_to_process('webui')

--- a/lib_comfyui/webui/settings.py
+++ b/lib_comfyui/webui/settings.py
@@ -12,6 +12,10 @@ def create_section():
 
     section = ('comfyui', "ComfyUI")
     shared.opts.add_option('comfyui_enabled', shared.OptionInfo(True, 'Enable sd-webui-comfyui extension', section=section))
+
+    shared.opts.add_option("comfyui_update_button", shared.OptionInfo(
+        "Update comfyui (requires reload ui)", "Update comfyui", gr.Button, section=section))
+
     shared.opts.add_option("comfyui_install_location", shared.OptionInfo(
         install_comfyui.default_install_location, "ComfyUI install location", section=section))
     shared.opts.add_option("comfyui_additional_args", shared.OptionInfo(
@@ -64,6 +68,17 @@ def update_reverse_proxy_enabled():
     from modules import shared
     reverse_proxy_enabled = shared.opts.data.get('comfyui_reverse_proxy_enabled', next(iter(reverse_proxy_choices.keys())))
     global_state.reverse_proxy_enabled = reverse_proxy_choices[reverse_proxy_enabled]() and getattr(shared.cmd_opts, "api", False)
+
+
+@ipc.restrict_to_process("webui")
+def subscribe_update_button(component, **kwargs):
+    if getattr(component, "elem_id", None) == "setting_comfyui_update_button":
+        component.click(fn=update_comfyui)
+
+
+@ipc.restrict_to_process("webui")
+def update_comfyui():
+    install_comfyui.update(get_install_location())
 
 
 ipc_strategy_choices = {


### PR DESCRIPTION
Fix second reported error in #149. Add update button so that if comfyui fails to load people are still able to attempt updating without having to type the commands manually.