### PR TITLE
Add workflows that run later in the pipeline

### DIFF
--- a/comfyui_custom_scripts/extensions/webuiNodes.js
+++ b/comfyui_custom_scripts/extensions/webuiNodes.js
@@ -85,8 +85,8 @@ app.registerExtension({
             getTypesLength(iframeInfo.webuiIoTypes.outputs),
             getTypesLength(iframeInfo.webuiIoTypes.inputs),
         );
-        // 240 and 40 are empirical values that seem to work
-        node.size = [240, 40 + distanceBetweenIoSlots * maxIoLength];
+        // 260 and 40 are empirical values that seem to work
+        node.size = [260, 40 + distanceBetweenIoSlots * maxIoLength];
     },
     async setup() {
         app.loadGraphData();

--- a/lib_comfyui/comfyui/iframe_requests.py
+++ b/lib_comfyui/comfyui/iframe_requests.py
@@ -78,7 +78,9 @@ class ComfyuiIFrameRequests:
             raise RuntimeError(f'Expected a sequence of length 2 for argument "max_amount_of_nodes", got {len(max_amount_of_nodes)} instead')
 
         workflow_graph = get_workflow_graph(workflow_type_id)
-        node_types = [node['type'] for node in workflow_graph['nodes']]
+        all_nodes = workflow_graph['nodes']
+        enabled_nodes = [node for node in all_nodes if node['mode'] != 2]
+        node_types = [node['type'] for node in enabled_nodes]
         amount_of_from_webui_nodes = len([t for t in node_types if t == 'FromWebui'])
         amount_of_to_webui_nodes = len([t for t in node_types if t == 'ToWebui'])
         max_from_webui_nodes = max_amount_of_io_nodes[0] if max_amount_of_io_nodes[0] is not None else amount_of_from_webui_nodes

--- a/lib_comfyui/comfyui/iframe_requests.py
+++ b/lib_comfyui/comfyui/iframe_requests.py
@@ -72,17 +72,17 @@ class ComfyuiIFrameRequests:
     @ipc.restrict_to_process('webui')
     def validate_amount_of_nodes_or_throw(
         workflow_type_id: str,
-        max_amount_of_nodes: Sequence[Optional[int]]
+        max_amount_of_io_nodes: Sequence[Optional[int]]
     ) -> None:
-        if len(max_amount_of_nodes) != 2:
+        if len(max_amount_of_io_nodes) != 2:
             raise RuntimeError(f'Expected a sequence of length 2 for argument "max_amount_of_nodes", got {len(max_amount_of_nodes)} instead')
 
         workflow_graph = get_workflow_graph(workflow_type_id)
         node_types = [node['type'] for node in workflow_graph['nodes']]
         amount_of_from_webui_nodes = len([t for t in node_types if t == 'FromWebui'])
         amount_of_to_webui_nodes = len([t for t in node_types if t == 'ToWebui'])
-        max_from_webui_nodes = max_amount_of_nodes[0] if max_amount_of_nodes[0] is not None else amount_of_from_webui_nodes
-        max_to_webui_nodes = max_amount_of_nodes[1] if max_amount_of_nodes[1] is not None else amount_of_to_webui_nodes
+        max_from_webui_nodes = max_amount_of_io_nodes[0] if max_amount_of_io_nodes[0] is not None else amount_of_from_webui_nodes
+        max_to_webui_nodes = max_amount_of_io_nodes[1] if max_amount_of_io_nodes[1] is not None else amount_of_to_webui_nodes
 
         if amount_of_from_webui_nodes > max_from_webui_nodes:
             raise TooManyFromWebuiNodesError(f'Unable to run the workflow {workflow_type_id}. '

--- a/lib_comfyui/comfyui/iframe_requests.py
+++ b/lib_comfyui/comfyui/iframe_requests.py
@@ -143,9 +143,9 @@ def clear_queue(queue: multiprocessing.Queue):
             pass
 
 
-class TooManyFromWebuiNodesError(ValueError):
+class TooManyFromWebuiNodesError(RuntimeError):
     pass
 
 
-class TooManyToWebuiNodesError(ValueError):
+class TooManyToWebuiNodesError(RuntimeError):
     pass

--- a/lib_comfyui/comfyui/iframe_requests.py
+++ b/lib_comfyui/comfyui/iframe_requests.py
@@ -75,7 +75,7 @@ class ComfyuiIFrameRequests:
         max_amount_of_nodes: Sequence[Optional[int]]
     ) -> None:
         if len(max_amount_of_nodes) != 2:
-            raise ValueError(f'Expected a sequence of length 2 for argument "max_amount_of_nodes", got {len(max_amount_of_nodes)} instead')
+            raise RuntimeError(f'Expected a sequence of length 2 for argument "max_amount_of_nodes", got {len(max_amount_of_nodes)} instead')
 
         workflow_graph = get_workflow_graph(workflow_type_id)
         node_types = [node['type'] for node in workflow_graph['nodes']]

--- a/lib_comfyui/comfyui/iframe_requests.py
+++ b/lib_comfyui/comfyui/iframe_requests.py
@@ -115,6 +115,10 @@ def extend_infotext_with_comfyui_workflows(p, tab):
     workflows = {}
     for workflow_type in external_code.get_workflow_types(tab):
         workflow_type_id = workflow_type.get_ids(tab)[0]
+        try:
+            ComfyuiIFrameRequests.validate_amount_of_nodes_or_throw(workflow_type_id, workflow_type.max_amount_of_io_nodes)
+        except RuntimeError:
+            continue
         if not external_code.is_workflow_type_enabled(workflow_type_id):
             continue
 

--- a/lib_comfyui/default_workflow_types.py
+++ b/lib_comfyui/default_workflow_types.py
@@ -26,6 +26,12 @@ postprocess_workflow_type = external_code.WorkflowType(
     default_workflow=external_code.AUTO_WORKFLOW,
     types='IMAGE',
 )
+postprocess_image_workflow_type = external_code.WorkflowType(
+    base_id='postprocess_image',
+    display_name='Postprocess Image',
+    default_workflow=external_code.AUTO_WORKFLOW,
+    types='IMAGE',
+)
 postprocess_latent_workflow_type = external_code.WorkflowType(
     base_id='postprocess_latent',
     display_name='Postprocess (latent)',
@@ -38,6 +44,7 @@ def add_default_workflow_types():
     workflow_types = [
         sandbox_tab_workflow_type,
         postprocess_workflow_type,
+        postprocess_image_workflow_type,
         postprocess_latent_workflow_type,
         preprocess_workflow_type,
         preprocess_latent_workflow_type,

--- a/lib_comfyui/default_workflow_types.py
+++ b/lib_comfyui/default_workflow_types.py
@@ -26,9 +26,9 @@ postprocess_workflow_type = external_code.WorkflowType(
     default_workflow=external_code.AUTO_WORKFLOW,
     types='IMAGE',
 )
-postprocess_image_workflow_type = external_code.WorkflowType(
-    base_id='postprocess_image',
-    display_name='Postprocess Image',
+before_save_image_workflow_type = external_code.WorkflowType(
+    base_id='before_save_image',
+    display_name='Before save image',
     default_workflow=external_code.AUTO_WORKFLOW,
     types='IMAGE',
 )
@@ -44,7 +44,7 @@ def add_default_workflow_types():
     workflow_types = [
         sandbox_tab_workflow_type,
         postprocess_workflow_type,
-        postprocess_image_workflow_type,
+        before_save_image_workflow_type,
         postprocess_latent_workflow_type,
         preprocess_workflow_type,
         preprocess_latent_workflow_type,

--- a/lib_comfyui/default_workflow_types.py
+++ b/lib_comfyui/default_workflow_types.py
@@ -20,17 +20,17 @@ preprocess_latent_workflow_type = external_code.WorkflowType(
     default_workflow=external_code.AUTO_WORKFLOW,
     types='LATENT',
 )
-postprocess_workflow_type = external_code.WorkflowType(
-    base_id='postprocess',
-    display_name='Postprocess',
-    default_workflow=external_code.AUTO_WORKFLOW,
-    types='IMAGE',
-)
 postprocess_latent_workflow_type = external_code.WorkflowType(
     base_id='postprocess_latent',
     display_name='Postprocess (latent)',
     default_workflow=external_code.AUTO_WORKFLOW,
     types='LATENT',
+)
+postprocess_workflow_type = external_code.WorkflowType(
+    base_id='postprocess',
+    display_name='Postprocess',
+    default_workflow=external_code.AUTO_WORKFLOW,
+    types='IMAGE',
 )
 postprocess_image_workflow_type = external_code.WorkflowType(
     base_id='postprocess_image',
@@ -51,8 +51,8 @@ def add_default_workflow_types():
         sandbox_tab_workflow_type,
         preprocess_workflow_type,
         preprocess_latent_workflow_type,
-        postprocess_workflow_type,
         postprocess_latent_workflow_type,
+        postprocess_workflow_type,
         postprocess_image_workflow_type,
         before_save_image_workflow_type,
     ]

--- a/lib_comfyui/default_workflow_types.py
+++ b/lib_comfyui/default_workflow_types.py
@@ -20,17 +20,17 @@ preprocess_latent_workflow_type = external_code.WorkflowType(
     default_workflow=external_code.AUTO_WORKFLOW,
     types='LATENT',
 )
-postprocess_latent_workflow_type = external_code.WorkflowType(
-    base_id='postprocess_latent',
-    display_name='Postprocess (latent)',
-    default_workflow=external_code.AUTO_WORKFLOW,
-    types='LATENT',
-)
 postprocess_workflow_type = external_code.WorkflowType(
     base_id='postprocess',
     display_name='Postprocess',
     default_workflow=external_code.AUTO_WORKFLOW,
     types='IMAGE',
+)
+postprocess_latent_workflow_type = external_code.WorkflowType(
+    base_id='postprocess_latent',
+    display_name='Postprocess (latent)',
+    default_workflow=external_code.AUTO_WORKFLOW,
+    types='LATENT',
 )
 postprocess_image_workflow_type = external_code.WorkflowType(
     base_id='postprocess_image',
@@ -51,8 +51,8 @@ def add_default_workflow_types():
         sandbox_tab_workflow_type,
         preprocess_workflow_type,
         preprocess_latent_workflow_type,
-        postprocess_latent_workflow_type,
         postprocess_workflow_type,
+        postprocess_latent_workflow_type,
         postprocess_image_workflow_type,
         before_save_image_workflow_type,
     ]

--- a/lib_comfyui/default_workflow_types.py
+++ b/lib_comfyui/default_workflow_types.py
@@ -37,14 +37,14 @@ postprocess_image_workflow_type = external_code.WorkflowType(
     display_name='Postprocess image',
     default_workflow=external_code.AUTO_WORKFLOW,
     types='IMAGE',
-    max_amount_of_io_nodes=[None, 1],
+    max_amount_of_ToWebui_nodes=1,
 )
 before_save_image_workflow_type = external_code.WorkflowType(
     base_id='before_save_image',
     display_name='Before save image',
     default_workflow=external_code.AUTO_WORKFLOW,
     types='IMAGE',
-    max_amount_of_io_nodes=[None, 1],
+    max_amount_of_ToWebui_nodes=1,
 )
 
 

--- a/lib_comfyui/default_workflow_types.py
+++ b/lib_comfyui/default_workflow_types.py
@@ -37,12 +37,14 @@ postprocess_image_workflow_type = external_code.WorkflowType(
     display_name='Postprocess image',
     default_workflow=external_code.AUTO_WORKFLOW,
     types='IMAGE',
+    max_amount_of_io_nodes=[None, 1],
 )
 before_save_image_workflow_type = external_code.WorkflowType(
     base_id='before_save_image',
     display_name='Before save image',
     default_workflow=external_code.AUTO_WORKFLOW,
     types='IMAGE',
+    max_amount_of_io_nodes=[None, 1],
 )
 
 

--- a/lib_comfyui/default_workflow_types.py
+++ b/lib_comfyui/default_workflow_types.py
@@ -20,9 +20,21 @@ preprocess_latent_workflow_type = external_code.WorkflowType(
     default_workflow=external_code.AUTO_WORKFLOW,
     types='LATENT',
 )
+postprocess_latent_workflow_type = external_code.WorkflowType(
+    base_id='postprocess_latent',
+    display_name='Postprocess (latent)',
+    default_workflow=external_code.AUTO_WORKFLOW,
+    types='LATENT',
+)
 postprocess_workflow_type = external_code.WorkflowType(
     base_id='postprocess',
     display_name='Postprocess',
+    default_workflow=external_code.AUTO_WORKFLOW,
+    types='IMAGE',
+)
+postprocess_image_workflow_type = external_code.WorkflowType(
+    base_id='postprocess_image',
+    display_name='Postprocess image',
     default_workflow=external_code.AUTO_WORKFLOW,
     types='IMAGE',
 )
@@ -32,22 +44,17 @@ before_save_image_workflow_type = external_code.WorkflowType(
     default_workflow=external_code.AUTO_WORKFLOW,
     types='IMAGE',
 )
-postprocess_latent_workflow_type = external_code.WorkflowType(
-    base_id='postprocess_latent',
-    display_name='Postprocess (latent)',
-    default_workflow=external_code.AUTO_WORKFLOW,
-    types='LATENT',
-)
 
 
 def add_default_workflow_types():
     workflow_types = [
         sandbox_tab_workflow_type,
-        postprocess_workflow_type,
-        before_save_image_workflow_type,
-        postprocess_latent_workflow_type,
         preprocess_workflow_type,
         preprocess_latent_workflow_type,
+        postprocess_latent_workflow_type,
+        postprocess_workflow_type,
+        postprocess_image_workflow_type,
+        before_save_image_workflow_type,
     ]
 
     for workflow_type in workflow_types:

--- a/lib_comfyui/external_code/api.py
+++ b/lib_comfyui/external_code/api.py
@@ -206,7 +206,7 @@ def run_workflow(
     batch_input: Any,
     queue_front: Optional[bool] = None,
     identity_on_error: Optional[bool] = False,
-    max_amount_of_nodes: Optional[Sequence[int]] = None
+    max_amount_of_io_nodes: Optional[Sequence[int]] = None
 ) -> List[Any]:
     """
     Run a comfyui workflow synchronously
@@ -221,7 +221,7 @@ def run_workflow(
             - if **input_types** is a str, **batch_input** should be a single value that should match the type expected by **input_types**.
         queue_front (Optional[bool]): Whether to queue the workflow before or after the currently queued workflows
         identity_on_error (Optional[bool]): Whether to return batch_input (converted to the type expected by workflow_type.types) instead of raising a RuntimeError when the workflow fails to run
-        max_amount_of_nodes: (Optional[Sequence[int]]): Maximum amount of From Webui and To Webui nodes present in the workflow, respectively. If either of the conditions are not met, a RuntimeError is raised
+        max_amount_of_io_nodes: (Optional[Sequence[int]]): Maximum amount of From Webui and To Webui nodes present in the workflow, respectively. If either of the conditions are not met, a RuntimeError is raised
     Returns:
         The outputs of the workflow, as a list.
         Each element of the list corresponds to one output node in the workflow.
@@ -248,18 +248,19 @@ def run_workflow(
     if queue_front is None:
         queue_front = getattr(global_state, 'queue_front', True)
 
-    if max_amount_of_nodes is None:
-        max_amount_of_nodes = [None, None]
+    if max_amount_of_io_nodes is None:
+        max_amount_of_io_nodes = [None, None]
 
     batch_input_args, input_types = _normalize_to_tuple(batch_input, workflow_type.input_types)
 
     if not candidate_ids:
-        raise ValueError(f'The workflow type {workflow_type.pretty_str()} does not exist on tab {tab}. Valid tabs for the given workflow type are: {workflow_type.tabs}')
+        raise ValueError(f'The workflow type {workflow_type.pretty_str()} does not exist on tab {tab}. '
+                         f'Valid tabs for the given workflow type are: {workflow_type.tabs}')
 
     workflow_type_id = candidate_ids[0]
 
     try:
-        ComfyuiIFrameRequests.validate_amount_of_nodes_or_throw(workflow_type_id, max_amount_of_nodes)
+        ComfyuiIFrameRequests.validate_amount_of_nodes_or_throw(workflow_type_id, max_amount_of_io_nodes)
     except RuntimeError as e:
         if not identity_on_error:
             raise e

--- a/lib_comfyui/external_code/api.py
+++ b/lib_comfyui/external_code/api.py
@@ -23,7 +23,8 @@ class WorkflowType:
     default_workflow: Union[str, Path] = "null"
     types: Union[str, Tuple[str, ...], Dict[str, str]] = dataclasses.field(default_factory=tuple)
     input_types: Union[str, Tuple[str, ...], Dict[str, str], None] = None
-    max_amount_of_io_nodes: Optional[Tuple[int | None, int | None]] = (None, None)
+    max_amount_of_ToWebui_nodes: Optional[int] = None
+    max_amount_of_FromWebui_nodes: Optional[int] = None
 
     def __post_init__(self):
         if isinstance(self.tabs, str):
@@ -256,7 +257,11 @@ def run_workflow(
     workflow_type_id = candidate_ids[0]
 
     try:
-        ComfyuiIFrameRequests.validate_amount_of_nodes_or_throw(workflow_type_id, workflow_type.max_amount_of_io_nodes)
+        ComfyuiIFrameRequests.validate_amount_of_nodes_or_throw(
+            workflow_type_id,
+            workflow_type.max_amount_of_FromWebui_nodes,
+            workflow_type.max_amount_of_ToWebui_nodes,
+        )
     except RuntimeError as e:
         if not identity_on_error:
             raise e

--- a/lib_comfyui/external_code/api.py
+++ b/lib_comfyui/external_code/api.py
@@ -260,7 +260,7 @@ def run_workflow(
 
     try:
         ComfyuiIFrameRequests.validate_amount_of_nodes_or_throw(workflow_type_id, max_amount_of_nodes)
-    except ValueError as e:
+    except RuntimeError as e:
         if not identity_on_error:
             raise e
 

--- a/lib_comfyui/external_code/api.py
+++ b/lib_comfyui/external_code/api.py
@@ -221,7 +221,7 @@ def run_workflow(
             - if **input_types** is a str, **batch_input** should be a single value that should match the type expected by **input_types**.
         queue_front (Optional[bool]): Whether to queue the workflow before or after the currently queued workflows
         identity_on_error (Optional[bool]): Whether to return batch_input (converted to the type expected by workflow_type.types) instead of raising a RuntimeError when the workflow fails to run
-        max_amount_of_nodes: (Optional[Sequence[int]]): Maximum amount of From Webui and To Webui nodes present in the workflow, respectively. If either of the conditions are not met, a RuntimeError is raised.
+        max_amount_of_nodes: (Optional[Sequence[int]]): Maximum amount of From Webui and To Webui nodes present in the workflow, respectively. If either of the conditions are not met, a RuntimeError is raised
     Returns:
         The outputs of the workflow, as a list.
         Each element of the list corresponds to one output node in the workflow.

--- a/lib_comfyui/webui/callbacks.py
+++ b/lib_comfyui/webui/callbacks.py
@@ -60,7 +60,6 @@ def on_before_image_saved(params):
         tab=tab,
         batch_input=type_conversion.webui_image_to_comfyui([params.image]),
         identity_on_error=True,
-        max_amount_of_io_nodes=[None, 1]
     )
 
     params.image = type_conversion.comfyui_image_to_webui(results[0], return_tensors=False)[0]

--- a/lib_comfyui/webui/callbacks.py
+++ b/lib_comfyui/webui/callbacks.py
@@ -60,7 +60,7 @@ def on_before_image_saved(params):
         tab=tab,
         batch_input=type_conversion.webui_image_to_comfyui([params.image]),
         identity_on_error=True,
-        max_amount_of_nodes=[None, 1]
+        max_amount_of_io_nodes=[None, 1]
     )
 
-    params.image.putdata(type_conversion.comfyui_image_to_webui(results[0], return_tensors=False)[0].getdata())
+    params.image = type_conversion.comfyui_image_to_webui(results[0], return_tensors=False)[0]

--- a/scripts/comfyui.py
+++ b/scripts/comfyui.py
@@ -81,20 +81,6 @@ class ComfyUIScript(scripts.Script):
         pp.images.extend(all_results)
         iframe_requests.extend_infotext_with_comfyui_workflows(p, self.get_tab())
 
-    def postprocess_image(self, p, pp, *args):
-        if not external_code.is_workflow_type_enabled(default_workflow_types.postprocess_image_workflow_type.get_ids(self.get_tab())[0]):
-            return
-
-        results = external_code.run_workflow(
-            workflow_type=default_workflow_types.postprocess_image_workflow_type,
-            tab=self.get_tab(),
-            batch_input=type_conversion.webui_image_to_comfyui([pp.image]),
-            identity_on_error=True,
-            max_amount_of_nodes=[None, 1]
-        )
-
-        pp.image = type_conversion.comfyui_image_to_webui(results[0], return_tensors=False)[0]
-
 
 def extract_contiguous_buckets(images, batch_size):
     current_shape = None

--- a/scripts/comfyui.py
+++ b/scripts/comfyui.py
@@ -92,7 +92,6 @@ class ComfyUIScript(scripts.Script):
             tab=self.get_tab(),
             batch_input=type_conversion.webui_image_to_comfyui([pp.image]),
             identity_on_error=True,
-            max_amount_of_io_nodes=[None, 1]
         )
 
         pp.image = type_conversion.comfyui_image_to_webui(results[0], return_tensors=False)[0]

--- a/scripts/comfyui.py
+++ b/scripts/comfyui.py
@@ -81,6 +81,20 @@ class ComfyUIScript(scripts.Script):
         pp.images.extend(all_results)
         iframe_requests.extend_infotext_with_comfyui_workflows(p, self.get_tab())
 
+    def postprocess_image(self, p, pp, *args):
+        if not external_code.is_workflow_type_enabled(default_workflow_types.postprocess_image_workflow_type.get_ids(self.get_tab())[0]):
+            return
+
+        results = external_code.run_workflow(
+            workflow_type=default_workflow_types.postprocess_image_workflow_type,
+            tab=self.get_tab(),
+            batch_input=type_conversion.webui_image_to_comfyui([pp.image]),
+            identity_on_error=True,
+            max_amount_of_nodes=[None, 1]
+        )
+
+        pp.image = type_conversion.comfyui_image_to_webui(results[0], return_tensors=False)[0]
+
 
 def extract_contiguous_buckets(images, batch_size):
     current_shape = None

--- a/scripts/comfyui.py
+++ b/scripts/comfyui.py
@@ -54,6 +54,8 @@ class ComfyUIScript(scripts.Script):
         patches.patch_processing(p)
 
     def postprocess_batch_list(self, p, pp, *args, **kwargs):
+        iframe_requests.extend_infotext_with_comfyui_workflows(p, self.get_tab())
+
         if not external_code.is_workflow_type_enabled(default_workflow_types.postprocess_workflow_type.get_ids(self.get_tab())[0]):
             return
 
@@ -79,7 +81,21 @@ class ComfyUIScript(scripts.Script):
 
         pp.images.clear()
         pp.images.extend(all_results)
-        iframe_requests.extend_infotext_with_comfyui_workflows(p, self.get_tab())
+
+    def postprocess_image(self, p, pp, *args):
+        if not external_code.is_workflow_type_enabled(
+                default_workflow_types.postprocess_image_workflow_type.get_ids(self.get_tab())[0]):
+            return
+
+        results = external_code.run_workflow(
+            workflow_type=default_workflow_types.postprocess_image_workflow_type,
+            tab=self.get_tab(),
+            batch_input=type_conversion.webui_image_to_comfyui([pp.image]),
+            identity_on_error=True,
+            max_amount_of_io_nodes=[None, 1]
+        )
+
+        pp.image = type_conversion.comfyui_image_to_webui(results[0], return_tensors=False)[0]
 
 
 def extract_contiguous_buckets(images, batch_size):

--- a/tests/lib_comfyui_tests/external_code_tests/run_workflow_test.py
+++ b/tests/lib_comfyui_tests/external_code_tests/run_workflow_test.py
@@ -12,8 +12,9 @@ class TestRunWorkflowBasicFunctionality(unittest.TestCase):
             'test_tab': True,
         })
 
+    @patch("lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.validate_amount_of_nodes_or_throw")
     @patch("lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.start_workflow_sync")
-    def test_valid_workflow_with_dict_types(self, mock_start_workflow):
+    def test_valid_workflow_with_dict_types(self, mock_start_workflow, _):
         mock_start_workflow.return_value = [{"key1": 0, "key2": 1}]
         workflow_type = external_code.WorkflowType(
             base_id="test",
@@ -33,8 +34,9 @@ class TestRunWorkflowBasicFunctionality(unittest.TestCase):
         )
         self.assertEqual(result, mock_start_workflow.return_value)
 
+    @patch("lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.validate_amount_of_nodes_or_throw")
     @patch("lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.start_workflow_sync")
-    def test_valid_workflow_with_tuple_types(self, mock_start_workflow):
+    def test_valid_workflow_with_tuple_types(self, mock_start_workflow, _):
         mock_start_workflow.return_value = [{"key1": 0, "key2": 1}]
         workflow_type = external_code.WorkflowType(
             base_id="test",
@@ -54,8 +56,9 @@ class TestRunWorkflowBasicFunctionality(unittest.TestCase):
         )
         self.assertEqual(result, [tuple(batch.values()) for batch in mock_start_workflow.return_value])
 
+    @patch("lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.validate_amount_of_nodes_or_throw")
     @patch('lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.start_workflow_sync')
-    def test_valid_workflow_with_str_types(self, mock_start_workflow):
+    def test_valid_workflow_with_str_types(self, mock_start_workflow, _):
         mock_start_workflow.return_value = [{"key1": 0}]
         workflow_type = external_code.WorkflowType(
             base_id="test",
@@ -75,8 +78,9 @@ class TestRunWorkflowBasicFunctionality(unittest.TestCase):
         )
         self.assertEqual(result, [next(iter(batch.values())) for batch in mock_start_workflow.return_value])
 
+    @patch("lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.validate_amount_of_nodes_or_throw")
     @patch('lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.start_workflow_sync')
-    def test_workflow_type_not_on_tab(self, mock_start_workflow):
+    def test_workflow_type_not_on_tab(self, mock_start_workflow, _):
         workflow_type = external_code.WorkflowType(
             base_id="test",
             display_name="Test Tab",
@@ -90,8 +94,9 @@ class TestRunWorkflowBasicFunctionality(unittest.TestCase):
 
         mock_start_workflow.assert_not_called()
 
+    @patch("lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.validate_amount_of_nodes_or_throw")
     @patch("lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.start_workflow_sync")
-    def test_workflow_type_not_enabled(self, mock_start_workflow):
+    def test_workflow_type_not_enabled(self, mock_start_workflow, _):
         setattr(global_state, 'enabled_workflow_type_ids', {})
 
         workflow_type = external_code.WorkflowType(
@@ -107,8 +112,9 @@ class TestRunWorkflowBasicFunctionality(unittest.TestCase):
 
         mock_start_workflow.assert_not_called()
 
+    @patch("lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.validate_amount_of_nodes_or_throw")
     @patch("lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.start_workflow_sync")
-    def test_multiple_outputs(self, mock_start_workflow):
+    def test_multiple_outputs(self, mock_start_workflow, _):
         mock_start_workflow.return_value = [{"key1": 0, "key2": 1}, {"key1": 2, "key2": 3}]
 
         workflow_type = external_code.WorkflowType(
@@ -130,8 +136,9 @@ class TestRunWorkflowInputValidation(unittest.TestCase):
             'test_tab': True,
         })
 
+    @patch("lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.validate_amount_of_nodes_or_throw")
     @patch("lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.start_workflow_sync")
-    def test_batch_input_mismatch_dict(self, mock_start_workflow):
+    def test_batch_input_mismatch_dict(self, mock_start_workflow, _):
         workflow_type = external_code.WorkflowType(
             base_id="test",
             display_name="Test Tab",
@@ -145,8 +152,9 @@ class TestRunWorkflowInputValidation(unittest.TestCase):
 
         mock_start_workflow.assert_not_called()
 
+    @patch("lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.validate_amount_of_nodes_or_throw")
     @patch("lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.start_workflow_sync")
-    def test_batch_input_mismatch_tuple(self, mock_start_workflow):
+    def test_batch_input_mismatch_tuple(self, mock_start_workflow, _):
         workflow_type = external_code.WorkflowType(
             base_id="test",
             display_name="Test Tab",
@@ -160,8 +168,9 @@ class TestRunWorkflowInputValidation(unittest.TestCase):
 
         mock_start_workflow.assert_not_called()
 
+    @patch("lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.validate_amount_of_nodes_or_throw")
     @patch("lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.start_workflow_sync")
-    def test_identity_on_error(self, mock_start_workflow):
+    def test_identity_on_error(self, mock_start_workflow, _):
         mock_start_workflow.side_effect = RuntimeError("Failed to execute workflow")
         workflow_type = external_code.WorkflowType(
             base_id="test",
@@ -186,8 +195,9 @@ class TestRunWorkflowInputValidation(unittest.TestCase):
             queue_front=True,
         )
 
+    @patch("lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.validate_amount_of_nodes_or_throw")
     @patch("lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.start_workflow_sync")
-    def test_multiple_candidate_ids(self, mock_start_workflow):
+    def test_multiple_candidate_ids(self, mock_start_workflow, _):
         workflow_type = external_code.WorkflowType(
             base_id="test",
             display_name="Test Tab",
@@ -202,8 +212,9 @@ class TestRunWorkflowInputValidation(unittest.TestCase):
 
         mock_start_workflow.assert_not_called()
 
+    @patch("lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.validate_amount_of_nodes_or_throw")
     @patch("lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.start_workflow_sync")
-    def test_invalid_batch_input_type(self, mock_start_workflow):
+    def test_invalid_batch_input_type(self, mock_start_workflow, _):
         workflow_type = external_code.WorkflowType(
             base_id="test",
             display_name="Test Tab",
@@ -224,8 +235,9 @@ class TestRunWorkflowExecutionBehavior(unittest.TestCase):
             'test_tab': True,
         })
 
+    @patch("lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.validate_amount_of_nodes_or_throw")
     @patch("lib_comfyui.comfyui.iframe_requests.ComfyuiIFrameRequests.start_workflow_sync")
-    def test_large_batch_input(self, mock_start_workflow):
+    def test_large_batch_input(self, mock_start_workflow, _):
         workflow_type = external_code.WorkflowType(
             base_id="test",
             display_name="Test Tab",


### PR DESCRIPTION
Adds 2 workflows:
- `Postprocess image`
- `Before save image`

There are a couple of things that can run after `postprocess_batch_list`, notably the `face restoration` and the `color corection` sections. 

These workflows cannot edit the size of the batch, but they run later in the pipeline. 

closes #175 